### PR TITLE
Fix percentage bar for smaller screens

### DIFF
--- a/components/Borrowing/index.tsx
+++ b/components/Borrowing/index.tsx
@@ -17,9 +17,10 @@ const CSS_NET_APR = (props) =>
 
 const StyledPercentage = Styled(Flex)`
  ${css({
-   justifyContent: 'center',
+   justifyContent: ['flex-start', null, null,null, null, 'center'],
    py: [20, 30, null, 80],
    px: [20, 40, null, 60],
+   ml: [55, 30,'5px',null, 15, '0px']
  })}
 `;
 


### PR DESCRIPTION
Adjusted alignment of percentage bar for smaller screens

![Screenshot from 2021-08-09 11-51-21](https://user-images.githubusercontent.com/41777225/128669284-e6065cd0-bc60-46ca-bc58-f29c8013fe20.png)
