### PR TITLE
Symbol issue fixed

### DIFF
--- a/components/Burn/index.tsx
+++ b/components/Burn/index.tsx
@@ -54,7 +54,7 @@ const Earn: React.FC<BurnProps> = ({ ancAssets }) => {
             <SimpleText>
               <b>Withdrawable Amount:</b> &nbsp;
             </SimpleText>
-            <SimpleText>{withdrawableAmount} bLUNA</SimpleText>
+            <SimpleText>{withdrawableAmount} LUNA</SimpleText>
           </StyledTextContainer>
         </Flex>
       </HeadingWrapper>


### PR DESCRIPTION
A small Issue corrected:
The withdrawable amount should be LUNA instead of bLUNA.