### PR TITLE
Save Thread Replies Cache

### DIFF
--- a/components/Agora/PostThreadModal/PostThreadView.tsx
+++ b/components/Agora/PostThreadModal/PostThreadView.tsx
@@ -10,7 +10,7 @@ import { CLUB_SERVER_ROOT, TEFI_DAGORA_CONTRACT_ADDRESS } from '../../../constan
 import { simulateSendContractMsg } from '../../../transactions/sendContract';
 import useWallet from '../../../lib/useWallet';
 import axios from 'axios';
-import { mutate } from 'swr';
+import { useSWRConfig } from 'swr';
 import { useThreadsByCategory } from '../../../data/useThreadsByCategory';
 
 const TITLE = 'Create A New Thread';
@@ -81,6 +81,7 @@ export const PostThreadView: React.FC<Props> = ({ onSend }) => {
   const [isTxCalculated, setIsTxCalculated] = useState(false);
   const [simulationLoading, setSimulationLoading] = useState(false);
   const { useConnectedWallet } = useWallet();
+  const { mutate } = useSWRConfig();
   const { getMutateKey } = useThreadsByCategory(category);
 
   const connectedWallet = useConnectedWallet();

--- a/data/useRepliesByThread.ts
+++ b/data/useRepliesByThread.ts
@@ -49,6 +49,13 @@ export const useRepliesByThread = (id: number | null) => {
 
   const allReplies: Reply[] = data ? data.reduce((acm, page) => [...acm, ...page], []) : [];
   const pageReplies = allReplies.slice(0, DEFAULT_LIMIT * currentPage);
+
+  const getMutateKey = (offset: number) => {
+    return `${CLUB_SERVER_ROOT}/dagora/thread/${id}/replies?limit=${DEFAULT_LIMIT}&offset=${offset}&isTestnet=${
+      process.env.NEXT_PUBLIC_IS_TESTNET ? true : false
+    }`;
+  };
+
   const state = {
     replies: pageReplies,
     size,
@@ -61,6 +68,7 @@ export const useRepliesByThread = (id: number | null) => {
     isEmpty,
     mutate,
     showLoadMore,
+    getMutateKey,
   };
 
   return state;


### PR DESCRIPTION
- onPost Success fn created to save thread reply in the cache

Screenshot: 

<img width="1369" alt="Screenshot 2022-10-20 at 10 03 31 PM" src="https://user-images.githubusercontent.com/24596621/197013782-c0fcf91c-ad60-4b75-b7b1-f0ef70c386e7.png">
